### PR TITLE
Make date time parsing more lax w.r.t. missing a time zone offset

### DIFF
--- a/certlogic/certlogic-js/README.md
+++ b/certlogic/certlogic-js/README.md
@@ -4,7 +4,7 @@
 It is a [specified](https://github.com/ehn-dcc-development/dgc-business-rules/blob/main/certlogic/specification/README.md) subset of [JsonLogic](https://jsonlogic.com/), extended with necessary custom operations - e.g. for working with dates.
 It's part of the efforts surrounding the [Digital COVID Certificate](https://ec.europa.eu/info/live-work-travel-eu/coronavirus-response/safe-covid-19-vaccines-europeans/eu-digital-covid-certificate_en), and as such serves as the basis for defining _interchangeable_ validation rules on top of the DCC.
 
-This NPM package consists of an implementation of CertLogic in JavaScript(/TypeScript), compatible with version **1.0.0** of the CertLogic specification.
+This NPM package consists of an implementation of CertLogic in JavaScript(/TypeScript), compatible with version **1.0.1** of the CertLogic specification.
 
 
 ## API

--- a/certlogic/certlogic-js/package.json
+++ b/certlogic/certlogic-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certlogic-js",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Implementation of CertLogic in TypeScript.",
   "keywords": [
     "json",

--- a/certlogic/certlogic-js/src/internals.ts
+++ b/certlogic/certlogic-js/src/internals.ts
@@ -34,6 +34,8 @@ export const isInt = (value: any): value is number => typeof value === "number" 
 export const isDate = (value: any): value is Date => typeof value === "object" && "toISOString" in value
 
 
+const leftPad = (str: string, len: number, char: string): string => char.repeat(len - str.length) + str
+
 /**
  * @returns A JavaScript {@see Date} object representing the date or date-time given as a string.
  * @throws An {@see Error} in case the string couldn't be parsed as a date or date-time.
@@ -42,17 +44,17 @@ export const dateFromString = (str: string) => {
     if (str.match(/^\d{4}-\d{2}-\d{2}$/)) {
         return new Date(str)
     }
-    const matcher = str.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+?)?(Z|([+-]\d{2}):?(\d{2})?)?$/)
-    //                                   1      2       3       4       5       6      7        8  9            10
+    const matcher = str.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+?)?(Z|(([+-])(\d{1,2}):?(\d{2})?))?$/)
+    //                                   1      2       3       4       5       6      7        8   910    11          12
     if (matcher) {
         let reformatted = `${matcher[1]}-${matcher[2]}-${matcher[3]}T${matcher[4]}:${matcher[5]}:${matcher[6]}`
         if (matcher[7]) {
             reformatted += matcher[7].padEnd(4, "0").substring(0, 4)
         }
         if (!matcher[8] || (matcher[8] === "Z")) {
-            reformatted += "Z"
+            reformatted += "Z"  // Assume timezone offset 'Z' when missing.
         } else {
-            reformatted += matcher[9] + ":" + (matcher[10] || "00")
+            reformatted += matcher[10] + leftPad(matcher[11], 2, "0") +  ":" + (matcher[12] || "00")
         }
         return new Date(reformatted)
     }

--- a/certlogic/certlogic-js/src/test/test-internals.ts
+++ b/certlogic/certlogic-js/src/test/test-internals.ts
@@ -40,7 +40,7 @@ describe("truthy and falsy", () => {
 
 describe("parsing of dates/date-times", () => {
 
-    const check = (dateTimeLike: string, expected: String) =>
+    const check = (dateTimeLike: string, expected: string, message?: string) =>
         equal(dateFromString(dateTimeLike).toISOString(), expected)
 
     it("construct a date from a string without time information (compliant with a JSON Schema \"date\" formatted string)", () => {
@@ -69,6 +69,20 @@ describe("parsing of dates/date-times", () => {
         check("2021-08-01T00:00:00.0001Z", "2021-08-01T00:00:00.000Z")    // 100 µs
         check("2021-08-01T00:00:00.00001Z", "2021-08-01T00:00:00.000Z")   //  10 µs
         check("2021-08-01T00:00:00.000001Z", "2021-08-01T00:00:00.000Z")  //   1 µs
+    })
+
+    it("construct date-times from strings which lack a timezone offset", () => {
+        check("2021-08-01", "2021-08-01T00:00:00.000Z")
+        check("2021-08-01T00:00:00", "2021-08-01T00:00:00.000Z")
+    })
+
+    it("construct date-times from strings which have a \"short\" timezone offset", () => {
+        check("2021-08-01T00:00:00+1:00", "2021-07-31T23:00:00.000Z")
+    })
+
+    it("should work for some samples from the QA test data", () => {
+        check("2021-05-20T12:34:56+00:00", "2021-05-20T12:34:56.000Z", "SI")
+        check("2021-06-29T14:02:07Z", "2021-06-29T14:02:07.000Z", "BE")
     })
 
 })

--- a/certlogic/certlogic-kotlin/README.md
+++ b/certlogic/certlogic-kotlin/README.md
@@ -1,7 +1,7 @@
 # CertLogic in Kotlin
 
 This module contains the reference implementation of CertLogic, written in Kotlin/Java.
-It's compatible with version **1.0.0** of the CertLogic specification.
+It's compatible with version **1.0.1** of the CertLogic specification.
 
 Apart from test sources, it consists of two files:
 

--- a/certlogic/certlogic-kotlin/pom.xml
+++ b/certlogic/certlogic-kotlin/pom.xml
@@ -106,10 +106,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>2.22.2</version>
                 <configuration>
                     <includes>
-                        <include>**/*Tests.java</include>
+                        <include>*Tests*</include>
                     </includes>
                 </configuration>
             </plugin>

--- a/certlogic/certlogic-kotlin/src/main/kotlin/eu/ehn/dcc/certlogic/JsonDateTime.java
+++ b/certlogic/certlogic-kotlin/src/main/kotlin/eu/ehn/dcc/certlogic/JsonDateTime.java
@@ -34,8 +34,8 @@ public class JsonDateTime extends ValueNode implements Comparable<JsonDateTime> 
         if (str.matches("^\\d{4}-\\d{2}-\\d{2}$")) {
             return JsonDateTime.fromStringInternal(str + "T00:00:00Z");
         }
-        final Pattern pattern = Pattern.compile("^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(\\.\\d+?)?(Z|([+-]\\d{2}):?(\\d{2})?)$");
-        //                                        1        2        3        4        5        6       7          8  9             10
+        final Pattern pattern = Pattern.compile("^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(\\.\\d+?)?(Z|(([+-])(\\d{1,2}):?(\\d{2})?))?$");
+        //                                        1        2        3        4        5        6       7          8  910    11          12
         Matcher matcher = pattern.matcher(str);
         if (matcher.matches()) {
             String reformatted = String.format("%s-%s-%sT%s:%s:%s", matcher.group(1), matcher.group(2), matcher.group(3), matcher.group(4), matcher.group(5), matcher.group(6));
@@ -43,9 +43,9 @@ public class JsonDateTime extends ValueNode implements Comparable<JsonDateTime> 
                 reformatted += String.format("%-4s", matcher.group(7)).replace(' ', '0').substring(0, 4);
             }
             if (matcher.group(8) == null || matcher.group(8).equals("Z")) {
-                reformatted += "Z";
+                reformatted += "Z";  // Assume timezone offset 'Z' when missing.
             } else {
-                reformatted += matcher.group(9) + ":" + (matcher.group(10) != null ? matcher.group(10) : "00");
+                reformatted += matcher.group(10) + String.format("%2s", matcher.group(11)).replaceAll(" ", "0") + ":" + (matcher.group(12) != null ? matcher.group(12) : "00");
             }
             return JsonDateTime.fromStringInternal(reformatted);
         }

--- a/certlogic/certlogic-kotlin/src/test/kotlin/eu/ehn/dcc/certlogic/JsonDateTimeTests.kt
+++ b/certlogic/certlogic-kotlin/src/test/kotlin/eu/ehn/dcc/certlogic/JsonDateTimeTests.kt
@@ -5,8 +5,8 @@ import kotlin.test.assertEquals
 
 class JsonDateTimeTests {
 
-    fun check(dateTimeLike: String, expected: String) {
-        assertEquals(expected, JsonDateTime.fromString(dateTimeLike).asText())
+    fun check(dateTimeLike: String, expected: String, message: String? = null) {
+        assertEquals(expected, JsonDateTime.fromString(dateTimeLike).asText(), message)
     }
 
     @Test
@@ -38,6 +38,24 @@ class JsonDateTimeTests {
         check("2021-08-01T00:00:00.0001Z", "2021-08-01T00:00:00.000Z")    // 100 µs
         check("2021-08-01T00:00:00.00001Z", "2021-08-01T00:00:00.000Z")   //  10 µs
         check("2021-08-01T00:00:00.000001Z", "2021-08-01T00:00:00.000Z")  //   1 µs
+    }
+
+    @Test
+    fun `construct date-times from strings which lack a timezone offset`() {
+        check("2021-08-01", "2021-08-01T00:00:00.000Z")
+        check("2021-08-01T00:00:00", "2021-08-01T00:00:00.000Z")
+    }
+
+    @Test
+    fun `construct date-times from strings which have a "short" timezone offset`() {
+        check("2021-08-01T00:00:00+1:00", "2021-08-01T00:00:00.000+01:00")
+        // java.time.OffsetDateTime keeps the timezone offset, and doesn't normalise to `Z`
+    }
+
+    @Test
+    fun `should work for some samples from the QA test data`() {
+        check("2021-05-20T12:34:56+00:00", "2021-05-20T12:34:56.000Z", "SI")
+        check("2021-06-29T14:02:07Z", "2021-06-29T14:02:07.000Z", "BE")
     }
 
 }

--- a/certlogic/specification/README.md
+++ b/certlogic/specification/README.md
@@ -3,7 +3,7 @@
 
 ## Version
 
-The semantic version identification of this specification is: **1.0.0**.
+The semantic version identification of this specification is: **1.0.1**.
 
 The version identification of implementations don't have to be in sync.
 Rather, implementations should specify with which version of the specification they're compatible.
@@ -70,15 +70,24 @@ This makes it possible to ensure consistent date/date-time representations acros
 The following date and date-time formats are allowed:
 
 	YYYY-MM-DD
+	YYYY-MM-DDThh:mm:ss
 	YYYY-MM-DDThh:mm:ssZ
+	YYYY-MM-DDThh:mm:ss[+-]h
 	YYYY-MM-DDThh:mm:ss[+-]hh
+	YYYY-MM-DDThh:mm:ss[+-]hmm
 	YYYY-MM-DDThh:mm:ss[+-]hhmm
+	YYYY-MM-DDThh:mm:ss[+-]h:mm
 	YYYY-MM-DDThh:mm:ss[+-]hh:mm
+	YYYY-MM-DDThh:mm:ss.S
 	YYYY-MM-DDThh:mm:ss.S+Z
+	YYYY-MM-DDThh:mm:ss.S+[+-]h
 	YYYY-MM-DDThh:mm:ss.S+[+-]hh
+	YYYY-MM-DDThh:mm:ss.S+[+-]hmm
 	YYYY-MM-DDThh:mm:ss.S+[+-]hhmm
+	YYYY-MM-DDThh:mm:ss.S+[+-]h:mm
 	YYYY-MM-DDThh:mm:ss.S+[+-]hh:mm
 
+When a timezone offset is missing, the offset `Z` is assumed.
 The last four formats specify sub-second time info, with any number of decimals being accepted.
 Any date(-time) is always normalised to milliseconds, with 3 places behind the decimal dot.
 All decimals beyond the 3rd one are ignored, effectively rounding _down_ to the nearest millisecond.

--- a/certlogic/specification/README.md
+++ b/certlogic/specification/README.md
@@ -88,7 +88,7 @@ The following date and date-time formats are allowed:
 	YYYY-MM-DDThh:mm:ss.S+[+-]hh:mm
 
 When a timezone offset is missing, the offset `Z` is assumed.
-The last four formats specify sub-second time info, with any number of decimals being accepted.
+The last eight formats specify sub-second time info, with any number of decimals being accepted.
 Any date(-time) is always normalised to milliseconds, with 3 places behind the decimal dot.
 All decimals beyond the 3rd one are ignored, effectively rounding _down_ to the nearest millisecond.
 

--- a/rules-runner/rules-runner-kotlin/pom.xml
+++ b/rules-runner/rules-runner-kotlin/pom.xml
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>2.22.2</version>
                 <configuration>
                     <includes>
                         <include>**/*Tests.java</include>

--- a/rules-runner/rules-runner-kotlin/src/test/kotlin/eu/ehn/dcc/rulesets/test-runner.kt
+++ b/rules-runner/rules-runner-kotlin/src/test/kotlin/eu/ehn/dcc/rulesets/test-runner.kt
@@ -53,7 +53,6 @@ fun File.fileNameWithoutExt(): CharSequence {
 }
 
 
-// FIXME  not picked up by Maven test
 internal class RunEURulesTests {
 
     val euTemplateRuleSet = readJson<RuleSet>(File("../../rulesets/EU/template-ruleset.json"))


### PR DESCRIPTION
+ add unit tests + bump version of spec -> 1.0.1 + version of impl -> 0.7.8 + get Kotlin unit tests to run from Maven

This should fix https://github.com/ehn-dcc-development/dgc-business-rules/issues/31