### PR TITLE
update deps of certlogic-html

### DIFF
--- a/certlogic/certlogic-html/package.json
+++ b/certlogic/certlogic-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certlogic-html",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "HTML renderer(s) for CertLogic expressions.",
   "keywords": [
     "json",
@@ -28,14 +28,14 @@
   "author": "Meinte Boersma <meinte.boersma@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "certlogic-js": "^0.9.1",
+    "certlogic-js": "^1.0.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@types/node": "^16.6.1",
-    "@types/react": "^17.0.18",
-    "@types/react-dom": "^17.0.9",
-    "typescript": "^4.3.5"
+    "@types/node": "^16.11.10",
+    "@types/react": "^17.0.37",
+    "@types/react-dom": "^17.0.11",
+    "typescript": "^4.5.2"
   }
 }


### PR DESCRIPTION
Main point is to update the certlogic-js beyond v1.0.0, to differentiate between spec. and impl. versions