### PR TITLE
Add render-as-compact-text function

### DIFF
--- a/certlogic/certlogic-js/CHANGELOG.md
+++ b/certlogic/certlogic-js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+# 1.1.0
+
+* Add a miscellaneous function `asCompactText` to the `misc` sub package.
+
+
 # 1.0.4
 
 * Implement factory functions for internal use, but don't expose these (yet)

--- a/certlogic/certlogic-js/README.md
+++ b/certlogic/certlogic-js/README.md
@@ -40,6 +40,8 @@ Finally, it also exposes a sub package `certlogic-js/misc` which contains additi
 * `desugar`: a function to "desugar" "extended CertLogic expression" to proper CertLogic expressions.
     At the moment, this only pertains to an additional `or` expression, which is desugared using [De Morgan's laws](https://en.wikipedia.org/wiki/De_Morgan%27s_laws).
     Note that *no specification is provided* for the "extended CertLogic expressions".
+* `asCompactText`: a function to render a CertLogic expression in a compact, textual notation - certainly more compact than the JSON format.
+    Note that this notation isn't specified (at this time).
 
 Note that documentation is...sparse outside of the [CertLogic specification](../specification/README.md), and the [overall documentation](https://github.com/ehn-dcc-development/dgc-business-rules/tree/main/documentation) around CertLogic and DCC business/validation rules.
 In particular, code-level documentation is largely absent.

--- a/certlogic/certlogic-js/package.json
+++ b/certlogic/certlogic-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certlogic-js",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Implementation of CertLogic in TypeScript",
   "keywords": [
     "json",

--- a/certlogic/certlogic-js/src/misc/index.ts
+++ b/certlogic/certlogic-js/src/misc/index.ts
@@ -1,1 +1,2 @@
 export { desugar } from "./desugar"
+export { renderAsCompactText } from "./textual-notation"

--- a/certlogic/certlogic-js/src/misc/textual-notation.ts
+++ b/certlogic/certlogic-js/src/misc/textual-notation.ts
@@ -1,0 +1,43 @@
+import { CertLogicExpression } from "../typings"
+
+
+/**
+ * Render the given CertLogic expression with a textual notation that's more compact than the JSON.
+ * The text returned is a single-line string.
+ *
+ * Note that this notation isn't specified (at this time).
+ * A CertLogic expression essentially is an AST, so it doesn't require to have the notion of operator precedence/priority.
+ * For those reasons, the textual notation typically comes with plenty of pairs of parentheses that often would be superfluous in languages having a specified textual notation.
+ */
+export const renderAsCompactText = (expr: CertLogicExpression): string => {
+    if (Array.isArray(expr)) {
+        return `[ ${expr.map(renderAsCompactText).join(", ")} ]`
+    }
+    if (typeof expr === "object" && Object.entries(expr).length === 1) {
+        const [ operator, operands ] = Object.entries(expr)[0]
+        switch (operator) {
+            case "var": return `/${operands}`
+            case "if": return `if (${renderAsCompactText(operands[0])}) then (${renderAsCompactText(operands[1])}) else (${renderAsCompactText(operands[2])})`
+            case "===":
+            case "and":
+            case ">":
+            case "<":
+            case ">=":
+            case "<=":
+            case "in":
+            case "+":
+            case "after":
+            case "before":
+            case "not-after":
+            case "not-before":
+                return operands.map(renderAsCompactText).map((r: CertLogicExpression) => `(${r})`).join(` ${operator} `)
+            case "!": return `not (${renderAsCompactText(operands[0])})`
+            case "plusTime": return `(${renderAsCompactText(operands[0])}) ${operands[1] >= 0 ? "+" : ""}${operands[1]} ${operands[2]}${Math.abs(operands[1]) === 1 ? "" : "s"}`
+            case "reduce": return `(${renderAsCompactText(operands[0])}).reduce((current, accumulator) → ${renderAsCompactText(operands[1])}, ${renderAsCompactText(operands[2])})`
+            case "extractFromUVCI": return `extract fragment ${operands[1]} from UVCI (${renderAsCompactText(operands[0])})`
+        }
+    }
+    // ultimate fall-back:
+    return JSON.stringify(expr, null, 2)
+}
+

--- a/certlogic/certlogic-js/src/test/misc/test-textual-notation.ts
+++ b/certlogic/certlogic-js/src/test/misc/test-textual-notation.ts
@@ -1,0 +1,68 @@
+const { equal } = require("chai").assert
+
+import { renderAsCompactText } from "../../misc"
+import * as f from "../../factories"
+import { CertLogicExpression } from "../../typings"
+
+
+describe("rendering as compact text", () => {
+
+    const rendersAs = (expr: CertLogicExpression, expected: string) => {
+        equal(renderAsCompactText(expr), expected)
+    }
+
+    it("works for literals", () => {
+        rendersAs(true, "true")
+        rendersAs(false, "false")
+        rendersAs(0, "0")
+        rendersAs(42, "42")
+        rendersAs(-1, "-1")
+        rendersAs("foo", `"foo"`)
+    })
+
+    it("works for data accesses", () => {
+        rendersAs(f.var_("payload.ver"), "/payload.ver")
+    })
+
+    it("works for arrays", () => {
+        rendersAs([true, false, f.var_("payload.ver")], "[ true, false, /payload.ver ]")
+    })
+
+    it("works for if-then-else", () => {
+        rendersAs(f.if_(true, true, false), "if (true) then (true) else (false)")
+    })
+
+
+    it("works for + operation", () => {
+        rendersAs(f.binOp_("+", 1, 2), "(1) + (2)")
+    })
+
+    it("works for and operation", () => {
+        rendersAs(f.and_(true, true, false), "(true) and (true) and (false)")
+    })
+
+    /*
+     * The + and and operators serve as a catch-all for all binary operators,
+     * which are therefore not tested explicitly.
+     */
+
+
+    it("works for not operation", () => {
+        rendersAs(f.not_(false), "not (false)")
+    })
+
+    it("works for plusTime operation", () => {
+        rendersAs(f.plusTime_(f.var_("now"), -1, "day"), "(/now) -1 day")
+        rendersAs(f.plusTime_(f.var_("now"), 2, "month"), "(/now) +2 months")
+    })
+
+    it("works for reduce operation", () => {
+        rendersAs(f.reduce_([ 1, 2, 3 ], f.binOp_("+", f.var_("current"), f.var_("accumulator")), 0), "([ 1, 2, 3 ]).reduce((current, accumulator) → (/current) + (/accumulator), 0)")
+    })
+
+    it("works for extractFromUVCI operation", () => {
+        rendersAs(f.extractFromUVCI_("UVCI:NL:foo/bar", 2), `extract fragment 2 from UVCI ("UVCI:NL:foo/bar")`)
+    })
+
+})
+


### PR DESCRIPTION
This function is moved from an adjacent project, and is meant to be able to visualize CertLogic expressions more compact, and more human-readable. The notation is similar to that from the `certlogic-html` package.