### PR TITLE
Clarify specification + improve documentation

### DIFF
--- a/certlogic/certlogic-js/README.md
+++ b/certlogic/certlogic-js/README.md
@@ -4,7 +4,7 @@
 It is a [specified](https://github.com/ehn-dcc-development/dgc-business-rules/blob/main/certlogic/specification/README.md) subset of [JsonLogic](https://jsonlogic.com/), extended with necessary custom operations - e.g. for working with dates.
 It's part of the efforts surrounding the [Digital COVID Certificate](https://ec.europa.eu/info/live-work-travel-eu/coronavirus-response/safe-covid-19-vaccines-europeans/eu-digital-covid-certificate_en), and as such serves as the basis for defining _interchangeable_ validation rules on top of the DCC.
 
-This NPM package consists of an implementation of CertLogic in JavaScript(/TypeScript) which is compatible with version **1.2.3** of [the specification](https://github.com/ehn-dcc-development/dgc-business-rules/tree/main/certlogic/specification/README.md).
+This NPM package consists of an implementation of CertLogic in JavaScript(/TypeScript) which is compatible with version **1.2.4** of [the specification](https://github.com/ehn-dcc-development/dgc-business-rules/tree/main/certlogic/specification/README.md).
 
 
 ## API

--- a/certlogic/certlogic-js/src/index.ts
+++ b/certlogic/certlogic-js/src/index.ts
@@ -3,4 +3,4 @@ export { isCertLogicExpression, isCertLogicOperation } from "./validation/index"
 export { isInt } from "./internals" // (export other internals only when necessary)
 export { evaluate } from "./evaluator"
 export const implementationVersion: string = require("../package.json").version
-export const specificationVersion: string = "1.2.3"
+export const specificationVersion: string = "1.2.4"

--- a/certlogic/certlogic-kotlin/README.md
+++ b/certlogic/certlogic-kotlin/README.md
@@ -1,7 +1,7 @@
 # CertLogic in Kotlin
 
 This module contains the reference implementation of CertLogic, written in Kotlin/Java.
-It's compatible with version **1.2.3** of the CertLogic specification.
+It's compatible with version **1.2.4** of the CertLogic specification.
 
 Apart from test sources, it consists of the following files:
 

--- a/certlogic/specification/CHANGELOG.md
+++ b/certlogic/specification/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.2.4 | 20211217 | Clarify semantics of the `plusTime` operation a bit more. Rename “UVCI” (incl. misspellings) to “UCI” where possible.
 | 1.2.3 | 20211209 | Clarify semantics of the `plusTime` operation.
 | 1.2.2 | 20211014 | Clarify semantics of the `in` operation, and of evaluation (and its order) in general.
 | 1.2.1 | 20210810 | Fix incorrect format in specification.

--- a/certlogic/specification/README.md
+++ b/certlogic/specification/README.md
@@ -247,13 +247,18 @@ All other special array operations can be implemented using (only) a `reduce` op
 To be able to access values in the original data context, CertLogic *may* expand beyond JsonLogic at some point by also adding a key-value pair with key `"data"` to the data object passed to the `<lambda>`, whose value is the original data context.
 
 
-### Extract data from an UVCI (`extractFromUVCI`)
+### Extract data from an UCI (`extractFromUVCI`)
 
-A DCC can contain UVCIs.
-Use cases exist which make it necessary to make decisions based on information contained in a UVCI.
-For more background information on the UVCI format, and design decisions around this operation: see [here](../../documentation/design-choices.md#operation-extract-from-UVCI).
+A DCC can contain UCIs - see [Annex 2 of this document](https://ec.europa.eu/health/sites/default/files/ehealth/docs/vaccination-proof_interoperability-guidelines_en.pdf).
 
-An UVCI-extraction operation has the following form:
+*Note* that since the publication of that document the term “Unique Vaccination Certificate Identifier” and its abbreviation “UVCI” have been deprecated in favour of “Unique Certificate Identifier” (UCI).
+For backward compatibility, code and data may still use “UVCI”.
+In particular, the optional prefix of a UCI's prefix is still `URN:UVCI:`.
+
+Use cases exist which make it necessary to make decisions based on information contained in a UCI.
+For more background information on the UCI format, and design decisions around this operation: see [here](../../documentation/design-choices.md#operation-extract-from-UVCI).
+
+An UCI-extraction operation has the following form:
 
     {
         "extractFromUVCI": [
@@ -266,7 +271,7 @@ The `<operand>` must be a string value, or `null`: anything else is an error.
 The `<index>` must be an integer.
 If the operand is `null`, `null` will be returned.
 
-The `extractFromUVCI` operation tries to interpret the given operand (now assumed to be not `null`, and a string) as a UVCI string according to Annex 2 in the [UVCI specification](https://ec.europa.eu/health/sites/default/files/ehealth/docs/vaccination-proof_interoperability-guidelines_en.pdf).
+The `extractFromUVCI` operation tries to interpret the given operand (now assumed to be not `null`, and a string) as a UCI string according to Annex 2 of [this document](https://ec.europa.eu/health/sites/default/files/ehealth/docs/vaccination-proof_interoperability-guidelines_en.pdf).
 It's *not* checked for compliance with this specification: see the [design decisions](../../documentation/design-choices.md#operation-extract-from-UVCI) for an explanation why that is.
 
 The string is split on separator characters (`/`, `#`, `:`) into string fragments.
@@ -308,6 +313,6 @@ A validator is provided in the form of the [`certlogic-js/validation` NPM sub pa
 
 ### Differences with JsonLogic implementations
 
-CertLogic is a subset of JsonLogic, but with custom operations that are specific to the domain of DCC added - currently: `plusTime`, and `extractFromUCVI`.
+CertLogic is a subset of JsonLogic, but with custom operations that are specific to the domain of DCC added - currently: `plusTime`, and `extractFromUVCI`.
 Implementors of the DCC validator using a JsonLogic implementation instead of a CertLogic implementation need to provide these custom operations to JsonLogic as well - see the [first paragraph of this document](../../documentation/implementations.md).
 

--- a/certlogic/specification/README.md
+++ b/certlogic/specification/README.md
@@ -216,9 +216,11 @@ A date-time offset operation has the following form:
     }
 
 A time unit is one of the following string values: "year", "month", "day", "hour".
-This operation is the *only* way to construct date-time values in CertLogic.
-Offsetting a date-time isn't affected by daylight saving time (DST transitions), nor by leap years or leap seconds.
+This operation is the *only* way to _construct_ date-time values in CertLogic.
 To convert a date(-time) string to a date-time value, specify an amount of `0`, and any time unit.
+Note that `plusTime` does not permit other date-time values: expressions such as `plusTime(plusTime("...", 0, "hour")`, 10, "day") are not valid.
+
+Offsetting a date-time isn't affected by daylight saving time (DST transitions), nor by leap years or leap seconds.
 
 
 ### Reduction (`reduce`)

--- a/certlogic/specification/README.md
+++ b/certlogic/specification/README.md
@@ -3,7 +3,7 @@
 
 ## Version
 
-The semantic version identification of this specification is: **1.2.3**.
+The semantic version identification of this specification is: **1.2.4**.
 
 The version identification of implementations don't have to be in sync.
 Rather, implementations should specify with which version of the specification they're compatible.

--- a/documentation/design-choices.md
+++ b/documentation/design-choices.md
@@ -63,23 +63,23 @@ Regarding the relation of CertLogic with JsonLogic, and the DCC validation rules
 
 ## Design choices specifics
 
-## Operation: extract from UVCI
+## Operation: extract from UCI
 
 An example use case for being able to extract information is the need to invalidate DCCs that have been issued by fraudulent pharmacies which can be identified by a certain part of the UVCI.
-The UVCI technical format is clearly defined in Annex 2 in the [UVCI specification](https://ec.europa.eu/health/sites/default/files/ehealth/docs/vaccination-proof_interoperability-guidelines_en.pdf).
+The UCI technical format is defined clearly in Annex 2 in the [UCI specification](https://ec.europa.eu/health/sites/default/files/ehealth/docs/vaccination-proof_interoperability-guidelines_en.pdf).
 It has a limited degree of freedom within the format -in particular, the precise format of individual fragments is not pre-defined (outside of the characters allowed).
-Also: the `URN:ICVI:` prefix is optional - e.g. UVCIs in DCCs issued by Luxembourg do not have the prefix.
+Also: the `URN:UVCI:` prefix is optional - e.g. UCIs in DCCs issued by Luxembourg do not have the prefix.
 
-There are several reasons to support extracting information from the UVCI with a specific operation, instead of using a more generic regex-based operation:
+There are several reasons to support extracting information from the UCI with a specific operation, instead of using a more generic regex-based operation:
 
 1. Regexes live in Pandora's box: they are extremely flexible but are not easy to use well, while it's easy to misuse them, either intentionally, or unintentionally.
 2. The CertLogic domain-specific language should be kept small in terms of the ground it can cover, to keep its usage simple, and ensure the language is easy to test.
 3. It's more difficult to assess whether a rule implemented using a generic but complex operation is GDPR-compliant than when it uses a simple, functionally-limited/restricted domain-specific operation.
 
-Note that this operation does *not* assume that the given string conforms to the UVCI format.
-In particular, it will not check conformance, and will not error on a malformed UVCI.
-The rationale for this is a combination of Postel's Law, and the fact that this operation could be used to check for/detect malformed UVCIs.
+Note that this operation does *not* assume that the given string conforms to the UCI format.
+In particular, it will not check conformance, and will not error on a malformed UCI.
+The rationale for this is a combination of Postel's Law, and the fact that this operation could be used to check for/detect malformed UCIs.
 
 Point in case: some DCCs have invalid prefixes like `urn:uvci:` (lowercase instead of uppercase-only), and `URN:UCI:` (missing `V`).
-To detect such UVCIs, one can use the `extractFromUVCI` operation with indices 0 and 1, because the invalid prefixes will *not* be ignored, but become fragments.
+To detect such UCIs, one can use the `extractFromUVCI` operation with indices 0 and 1, because the invalid prefixes will *not* be ignored, but become fragments.
 

--- a/documentation/how-to.md
+++ b/documentation/how-to.md
@@ -59,18 +59,7 @@ The following things can be helpful:
 
 * The CertLogic specification is stricter than what can be expressed in a JSON Schema.
     To validate a CertLogic expression against the specification, the [`certlogic-js/validation` NPM sub package](../certlogic-js/README.md) can be used.
-    This sub package is part of the `certlogic-js` NPM package that can be installed using the CLI command
-
-        $ npm add certlogic-js
-
-    (The `$` represents the CLI prompt.)
-    This commands takes one CLI argument: a path to a JSON file containing a CertLogic expression.
-    It will print a list of validation errors to `stdout` - if that's empty, the CertLogic expression is correct.
-
-    It requires [NPM](https://www.npmjs.com/) ([Node.js](https://nodejs.org/)'s package manager) or its alternative [yarn](https://yarnpkg.com/).
-    For the moment, this tool has to be installed from this GitHub repository, using a relative path.
-
-    The tool exposes an executable `certlogic-validate`, which can be run from the CLI as follows:
+    The `certlogic-js` NPM module exposes an executable `certlogic-validate`, which can be run from the CLI as follows:
 
         $ npx certlogic-validate <path to JSON file containing a single CertLogic expression>
 
@@ -78,12 +67,15 @@ The following things can be helpful:
 
         $ ./node_modules/.bin/certlogic-validate <path to JSON file containing a single CertLogic expression>
 
+    (The `$` represents the CLI prompt.)
+    This commands takes one CLI argument: a path to a JSON file containing a CertLogic expression.
+    It will print a list of validation errors to `stdout` - if that's empty, the CertLogic expression is correct.
     This works from the directory where you installed `certlogic-js`.
     Alternatively, you can use `npx` (when installed) to directly execute it.
     Inside NPM `scripts`, you can remove the `./node_modules/.bin/` prefix.
 
-* The `certlogic-js` validator tool does not have or use any knowledge about the shape of the data the given CertLogic expression is executed against.
-    That will be addressed later on.
+    The `certlogic-js` validator tool does not have or use any knowledge about the shape of the data the given CertLogic expression is executed against.
+    (That will be addressed later on.)
 
 
 ## Testing a rule
@@ -188,7 +180,19 @@ runRuleSet(ruleSet, data)
 Feel free to replace the use of `java.io.File` with an alternative more suitable in the context of e.g. Android.
 
 
-#### Gradle
+## Using CertLogic as dependency
+
+### NPM
+
+The `certlogic-js` [NPM](https://www.npmjs.com/) package can be installed using the CLI command
+
+    $ npm add certlogic-js
+
+NPM is the package manager shipped by default with [Node.js](https://nodejs.org/).
+Its alternative is [yarn](https://yarnpkg.com/).
+
+
+### Gradle
 
 The following `build.gradle` Gradle build script fragment sets up the dependencies on `rules-runner-kotlin` and `certlogic-kotlin`:
 
@@ -229,7 +233,7 @@ allprojects {
 ```
 
 
-#### Maven
+### Maven
 
 The following XML fragment specifies the dependencies in a `pom.xml` when using Maven:
 


### PR DESCRIPTION
- Clarify semantics of the `plusTime` operation a bit more.
- Rename “UVCI” (incl. misspellings) to “UCI” where possible.